### PR TITLE
link to gohu.eu is dead

### DIFF
--- a/patched-fonts/Gohu/readme.md
+++ b/patched-fonts/Gohu/readme.md
@@ -5,7 +5,7 @@ A font for programming and terminal use.
 
 TrueType automatically traced, with available bitmaps in heights of 11 and 14 pixels.
 
-Copyright 2010 by Hugo Chargois (http://font.gohu.eu)
+Copyright 2010 by Hugo Chargois (https://font.gohu.org)
 
 Converted by Guilherme Maeda (github.com/koemaeda)
 


### PR DESCRIPTION
Replaced with link to gohu.org


#### Description

The readme linked to gohu.eu. This leads to some dubious tracking site.

#### What does this Pull Request (PR) do?

Fix the readme

#### How should this be manually tested?

Read it ;)

#### Any background context you can provide?

no

#### What are the relevant tickets (if any)?

none

#### Screenshots (if appropriate or helpful)
